### PR TITLE
Fix fetch error handling

### DIFF
--- a/cmd/hrv/cmd/fetch.go
+++ b/cmd/hrv/cmd/fetch.go
@@ -124,6 +124,7 @@ var fetchCmd = &cobra.Command{
 				c, err := collector.NewCollector(ctx, t, l)
 				if err != nil {
 					l.Error("Fetch error", zap.String("host", t.Host), zap.String("path", t.Path), zap.String("error", err.Error()))
+					return
 				}
 				err = c.Fetch(d.In(), st, et, t.MultiLine)
 				if err != nil {


### PR DESCRIPTION
```console
2019-09-25T10:32:39.957+0900    ERROR    Fetch error    {"host": "example.com", "path": "/var/log/syslog*", "error": "sshkeys: Invalid Passphrase"}
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x4d9bc9a]

goroutine 69 [running]:
github.com/k1LoW/harvest/collector.(*Collector).Fetch(0x0, 0xc0000da960, 0xc0000d8060, 0xc0000d8080, 0x0, 0x0, 0x0)
    /Users/k1low/src/github.com/k1LoW/harvest/collector/collector.go:93 +0x5a
github.com/k1LoW/harvest/cmd/hrv/cmd.glob..func5.1(0xc000452060, 0xc0005a0800, 0x5377a60, 0xc000430300, 0xc00027d2c0, 0xc0004c57a0, 0xc0000d8060, 0xc0000d8080, 0xc000444b40)
    /Users/k1low/src/github.com/k1LoW/harvest/cmd/hrv/cmd/fetch.go:128 +0x10e
created by github.com/k1LoW/harvest/cmd/hrv/cmd.glob..func5
    /Users/k1low/src/github.com/k1LoW/harvest/cmd/hrv/cmd/fetch.go:121 +0x74b
```