### PR TITLE
Fix panic: runtime error: invalid memory address or nil pointer dereference

### DIFF
--- a/cmd/hrv/cmd/stream.go
+++ b/cmd/hrv/cmd/stream.go
@@ -114,6 +114,7 @@ var streamCmd = &cobra.Command{
 				c, err := collector.NewCollector(ctx, t, l)
 				if err != nil {
 					l.Error("Stream error", zap.String("host", t.Host), zap.String("path", t.Path), zap.String("error", err.Error()))
+					return
 				}
 				err = c.Stream(logChan, t.MultiLine)
 				if err != nil {


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x4e31c04]

goroutine 432 [running]:
github.com/k1LoW/harvest/collector.(*Collector).Stream(0x0, 0xc0000e40c0, 0x0, 0x0, 0x0)
        /Users/k1low/src/github.com/k1LoW/harvest/collector/collector.go:118 +0x54
github.com/k1LoW/harvest/cmd/hrv/cmd.glob..func9.1(0xc0004f0060, 0x54974a0, 0xc0000c91c0, 0xc000404840, 0xc0000e40c0, 0xc0004a24b0)
        /Users/k1low/src/github.com/k1LoW/harvest/cmd/hrv/cmd/stream.go:118 +0xd5
created by github.com/k1LoW/harvest/cmd/hrv/cmd.glob..func9
        /Users/k1low/src/github.com/k1LoW/harvest/cmd/hrv/cmd/stream.go:112 +0x4d4
```